### PR TITLE
🔧 tsconfig strict 의도대로 적용 안되는 거 수정

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -14,9 +14,6 @@
     "incremental": true,
     "skipLibCheck": true,
     "strict": true,
-    "strictNullChecks": false,
-    "noImplicitAny": false,
-    "strictBindCallApply": false,
     "forceConsistentCasingInFileNames": false,
     "noFallthroughCasesInSwitch": false,
     "paths": {


### PR DESCRIPTION
## 개요(문제 요약)
- strict: true 적용 안되는 세부 설정들 수정

## 작업 사항
- false로 덮어씌우던 엄격한 타입 확인 설정들 삭제

## 참고 사항
